### PR TITLE
[FIX] application.yml - syntax error

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     username: guest
     password: guest
     request:
-      exchenge:
+      exchange:
         producer: ex.producer.aula-spring
       routing-key:
         producer: rk.producer.aula-spring


### PR DESCRIPTION
Em "application.yml", o property "exchenge" deveria ser "exchange".

Alterações em:
- Application.yml

exchenge: producer: ex.producer.aula-spring

Para:
exchange: producer: ex.producer.aula-spring